### PR TITLE
Updated resolve condition only if backend connection fails

### DIFF
--- a/apim.json
+++ b/apim.json
@@ -59,7 +59,7 @@
             "type": "string"
         },
         "inbound_policy":{
-            "defaultValue": "<policies>\r\n  <inbound>\r\n    <base />\r\n    <set-backend-service backend-id=\"servicefabric\" sf-service-instance-name=\"fabric:/ApiApplication/WebApiService\" sf-resolve-condition=\"@(context.LastError?.Reason == \"\BackendConnectionFailure")\" />\r\n  </inbound>\r\n  <backend>\r\n    <base />\r\n  </backend>\r\n  <outbound>\r\n    <base />\r\n  </outbound>\r\n  <on-error>\r\n    <base />\r\n  </on-error>\r\n</policies>",
+            "defaultValue": "<policies>\r\n  <inbound>\r\n    <base />\r\n    <set-backend-service backend-id=\"servicefabric\" sf-service-instance-name=\"fabric:/ApiApplication/WebApiService\" sf-resolve-condition=\"@(context.LastError?.Reason == \"BackendConnectionFailure\")\" />\r\n  </inbound>\r\n  <backend>\r\n    <base />\r\n  </backend>\r\n  <outbound>\r\n    <base />\r\n  </outbound>\r\n  <on-error>\r\n    <base />\r\n  </on-error>\r\n</policies>",
             "type": "string"
         },
         "apis_service_fabric_app_name": {

--- a/apim.json
+++ b/apim.json
@@ -59,7 +59,7 @@
             "type": "string"
         },
         "inbound_policy":{
-            "defaultValue": "<policies>\r\n  <inbound>\r\n    <base />\r\n    <set-backend-service backend-id=\"servicefabric\" sf-service-instance-name=\"fabric:/ApiApplication/WebApiService\" sf-resolve-condition=\"@((int)context.Response.StatusCode != 200)\" />\r\n  </inbound>\r\n  <backend>\r\n    <base />\r\n  </backend>\r\n  <outbound>\r\n    <base />\r\n  </outbound>\r\n  <on-error>\r\n    <base />\r\n  </on-error>\r\n</policies>",
+            "defaultValue": "<policies>\r\n  <inbound>\r\n    <base />\r\n    <set-backend-service backend-id=\"servicefabric\" sf-service-instance-name=\"fabric:/ApiApplication/WebApiService\" sf-resolve-condition=\"@(context.LastError?.Reason == \"\BackendConnectionFailure")\" />\r\n  </inbound>\r\n  <backend>\r\n    <base />\r\n  </backend>\r\n  <outbound>\r\n    <base />\r\n  </outbound>\r\n  <on-error>\r\n    <base />\r\n  </on-error>\r\n</policies>",
             "type": "string"
         },
         "apis_service_fabric_app_name": {


### PR DESCRIPTION
The current resolve condition is based on return anything other than 200 (OK). This is sub-optimal as it will keep trying even if it reached the desired application. Possible return codes:
- 201: if a resource was created
- 404: if a resource was not found

As commented in this issue (https://github.com/Azure/service-fabric-issues/issues/346), a better starting point would be resolving only if last error was backend connection failure.